### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/ddollar.php
+++ b/syntax/ddollar.php
@@ -25,7 +25,7 @@ class syntax_plugin_latex_ddollar extends syntax_plugin_latex_common {
    /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array("$$".$match."$$",$state,'class'=>"latex_displayed", 'title'=>"Equation", NULL);

--- a/syntax/displaymath.php
+++ b/syntax/displaymath.php
@@ -25,7 +25,7 @@ class syntax_plugin_latex_displaymath extends syntax_plugin_latex_common {
    /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array("\\begin{displaymath}".$match."\\end{displaymath}",$state,'class'=>"latex_displayed", 'title'=>"Equation", NULL);

--- a/syntax/dollar.php
+++ b/syntax/dollar.php
@@ -20,7 +20,7 @@ class syntax_plugin_latex_dollar extends syntax_plugin_latex_common {
    /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array("$".$match."$",$state,'class'=>"latex_inline", 'title'=>"Math", NULL);

--- a/syntax/eqnarray.php
+++ b/syntax/eqnarray.php
@@ -24,7 +24,7 @@ class syntax_plugin_latex_eqnarray extends syntax_plugin_latex_common {
    /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array("\\begin{eqnarray}".$match."\\end{eqnarray}",$state,'class'=>"latex_displayed", 'title'=>"Equations", NULL);

--- a/syntax/eqnarraystar.php
+++ b/syntax/eqnarraystar.php
@@ -24,7 +24,7 @@ class syntax_plugin_latex_eqnarraystar extends syntax_plugin_latex_common {
    /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array("\\begin{eqnarray*}".$match."\\end{eqnarray*}",$state,'class'=>"latex_displayed", 'title'=>"Equations", NULL);

--- a/syntax/equation.php
+++ b/syntax/equation.php
@@ -25,7 +25,7 @@ class syntax_plugin_latex_equation extends syntax_plugin_latex_common {
    /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array("\\begin{equation}".$match."\\end{equation}",$state,'class'=>"latex_displayed", 'title'=>"Equation", NULL);

--- a/syntax/equationstar.php
+++ b/syntax/equationstar.php
@@ -25,7 +25,7 @@ class syntax_plugin_latex_equationstar extends syntax_plugin_latex_common {
    /**
     * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array("\\begin{equation*}".$match."\\end{equation*}",$state,'class'=>"latex_displayed", 'title'=>"Equation", NULL);

--- a/syntax/latex.php
+++ b/syntax/latex.php
@@ -31,7 +31,7 @@ class syntax_plugin_latex_latex extends syntax_plugin_latex_common {
     /**
      * Handle the match
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 	  if($state != DOKU_LEXER_UNMATCHED)
 		return array($match,$state,NULL);
 	  return array($match,$state,'class'=>"latex_inline", 'title'=>"LaTeX", NULL);


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
